### PR TITLE
优化谱面容错

### DIFF
--- a/SimaiSharp/src/Internal/LexicalAnalysis/Tokenizer.cs
+++ b/SimaiSharp/src/Internal/LexicalAnalysis/Tokenizer.cs
@@ -136,7 +136,8 @@ namespace SimaiSharp.Internal.LexicalAnalysis
                 }
 
                 default:
-                    throw new UnsupportedSyntaxException(_line, _charIndex);
+                    // throw new UnsupportedSyntaxException(_line, _charIndex);
+                    return null;
             }
         }
 

--- a/SimaiSharp/src/Internal/SyntacticAnalysis/States/SlideReader.cs
+++ b/SimaiSharp/src/Internal/SyntacticAnalysis/States/SlideReader.cs
@@ -191,7 +191,7 @@ namespace SimaiSharp.Internal.SyntacticAnalysis.States
 				}
 			}
 
-			var durationDeclaration = token.lexeme.Span[startOfDurationDeclaration..];
+			var durationDeclaration = token.lexeme.Span[startOfDurationDeclaration..].ToString().Replace(" ", "");
 			var indexOfSeparator    = durationDeclaration.IndexOf(':');
 
 			// Slide duration:

--- a/SimaiSharp/src/Internal/SyntacticAnalysis/States/SlideReader.cs
+++ b/SimaiSharp/src/Internal/SyntacticAnalysis/States/SlideReader.cs
@@ -104,7 +104,8 @@ namespace SimaiSharp.Internal.SyntacticAnalysis.States
 					path.type = NoteType.Break;
 					return;
 				default:
-					throw new UnsupportedSyntaxException(token.line, token.character);
+					// throw new UnsupportedSyntaxException(token.line, token.character);
+					return;
 			}
 		}
 

--- a/SimaiSharp/src/SimaiFile.cs
+++ b/SimaiSharp/src/SimaiFile.cs
@@ -26,9 +26,9 @@ namespace SimaiSharp
             var fileStream = new FileStream(file.FullName, FileMode.Open, FileAccess.Read);
 
             // Determine the encoding of the file
-            var buffer       = new byte[64];
+            var buffer = new byte[64];
             var numCharsRead = fileStream.Read(buffer, 0, 64);
-            var encoding     = buffer[..numCharsRead].TryGetEncoding(sampleSize);
+            var encoding = buffer[..numCharsRead].TryGetEncoding(sampleSize);
 
             // We've already read 64 chars, so we'll reset here.
             fileStream.Position = 0;
@@ -59,7 +59,7 @@ namespace SimaiSharp
 
         public IEnumerable<KeyValuePair<string, string>> ToKeyValuePairs()
         {
-            var currentKey   = string.Empty;
+            var currentKey = string.Empty;
             var currentValue = new StringBuilder();
 
             while (!_simaiReader.EndOfStream)
@@ -78,6 +78,8 @@ namespace SimaiSharp
                     }
 
                     var keyValuePair = line.Split('=', 2);
+                    if (keyValuePair.Length != 2)
+                        continue;
                     currentKey = keyValuePair[0][1..];
                     currentValue.AppendLine(keyValuePair[1]);
                 }
@@ -93,10 +95,10 @@ namespace SimaiSharp
 
         public string? GetValue(string key)
         {
-            var keyPart       = $"&{key}=";
+            var keyPart = $"&{key}=";
             var keyPartLength = keyPart.Length;
 
-            var result       = new StringBuilder();
+            var result = new StringBuilder();
             var readingValue = false;
 
             while (!_simaiReader.EndOfStream)


### PR DESCRIPTION
解决一些谱面因为不标准而报错的问题，比如说这个谱面 https://www.bilibili.com/video/BV1HN4y1v7jG/

`5>5x[16:8]b` 这里多了一个 x，去掉也无所谓  
`8-4[1 6:2]` 这里多一个空格，去掉就能识别

而 Majdata 可以忽略这样的错误